### PR TITLE
more lax linting

### DIFF
--- a/javascript/linters/.eslintrc
+++ b/javascript/linters/.eslintrc
@@ -32,22 +32,21 @@
     /**
      * ES6
      */
-    "arrow-parens": [2, "as-needed"],
-    "arrow-spacing": [2, { "before": true, "after": true }],
-    "generator-star-spacing": [2, "after"],
+    "arrow-parens": [1, "as-needed"],
+    "arrow-spacing": [1, { "before": true, "after": true }],
+    "generator-star-spacing": [1, "after"],
     "no-const-assign": 2,
     "no-dupe-class-members": 2,
     "no-this-before-super": 2,
-    "no-var": 2,
-    "object-shorthand": [2, "always"],
-    "prefer-const": 2,
-    "prefer-spread": 2,
-    "prefer-template": 2,
+    "no-var": 1,
+    "object-shorthand": [1, "always"],
+    "prefer-const": 1,
+    "prefer-spread": 1,
+    "prefer-template": 1,
 
     /**
      * Variables
      */
-    "no-catch-shadow": 2,
     "no-delete-var": 2,
     "no-label-var": 2,
     "no-shadow-restricted-names": 2,
@@ -70,14 +69,14 @@
      * Possible errors
      */
     "comma-dangle": [
-      2,
+      1,
       "always-multiline"
     ],
     "no-cond-assign": [2, "always"],
-    "no-console": 1,
+    "no-console": 2,
     "no-constant-condition": 1,
     "no-control-regex": 2,
-    "no-debugger": 1,
+    "no-debugger": 2,
     "no-dupe-args": 2,
     "no-dupe-keys": 2,
     "no-duplicate-case": 2,
@@ -85,15 +84,15 @@
     "no-empty": 2,
     "no-ex-assign": 2,
     "no-extra-boolean-cast": 0,
-    "no-extra-parens": 2,
-    "no-extra-semi": 2,
+    "no-extra-parens": 1,
+    "no-extra-semi": 1,
     "no-func-assign": 2,
     "no-inner-declarations": 2,
     "no-invalid-regexp": 2,
     "no-irregular-whitespace": 2,
     "no-negated-in-lhs": 2,
     "no-obj-calls": 2,
-    "no-regex-spaces": 2,
+    "no-regex-spaces": 1,
     "no-sparse-arrays": 2,
     "no-unreachable": 2,
     "use-isnan": 2,
@@ -105,14 +104,14 @@
      */
     "block-scoped-var": 2,
     "consistent-return": 2,
-    "curly": 2,
-    "default-case": 2,
+    "curly": [2, "multi"],
+    "default-case": 1,
     "dot-notation": [2, {
       "allowKeywords": true
     }],
     "eqeqeq": 2,
     "guard-for-in": 2,
-    "no-alert": 1,
+    "no-alert": 2,
     "no-caller": 2,
     "no-div-regex": 2,
     "no-else-return": 2,
@@ -126,7 +125,7 @@
     "no-implied-eval": 2,
     "no-lone-blocks": 2,
     "no-loop-func": 1,
-    "no-multi-spaces": 2,
+    "no-multi-spaces": 1,
     "no-multi-str": 2,
     "no-native-reassign": 2,
     "no-new-func": 2,
@@ -156,60 +155,60 @@
     /**
      * Style
      */
-    "brace-style": [2,
+    "brace-style": [1,
       "1tbs", {
         "allowSingleLine": true
       }
     ],
-    "camelcase": [2, {
+    "camelcase": [1, {
       "properties": "never"
     }],
-    "comma-spacing": [2, {
+    "comma-spacing": [1, {
       "before": false,
       "after": true
     }],
-    "comma-style": [2, "last"],
-    "consistent-this": [2, "self"],
-    "eol-last": 2,
+    "comma-style": [1, "last"],
+    "consistent-this": [1, "self"],
+    "eol-last": 1,
     "func-names": 1,
-    "indent": [2, 4],
-    "key-spacing": [2, {
+    "indent": [1, 4],
+    "key-spacing": [1, {
       "beforeColon": false,
       "afterColon": true
     }],
-    "linebreak-style": [2, "unix"],
-    "new-cap": [2, {
+    "linebreak-style": [1, "unix"],
+    "new-cap": [1, {
       "newIsCap": true
     }],
-    "no-multiple-empty-lines": [2, {
+    "no-multiple-empty-lines": [1, {
       "max": 2
     }],
     "no-nested-ternary": 2,
     "no-new-object": 2,
-    "no-spaced-func": 2,
-    "no-trailing-spaces": 2,
+    "no-spaced-func": 1,
+    "no-trailing-spaces": 1,
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 2,
-    "one-var": [2, "never"],
-    "padded-blocks": [2, "never"],
+    "one-var": [1, "never"],
+    "padded-blocks": [1, "never"],
     "quote-props": 0,
     "quotes": [
-      2, "single", "avoid-escape"
+      1, "single", "avoid-escape"
     ],
     "semi": [2, "always"],
-    "semi-spacing": [2, {
+    "semi-spacing": [1, {
       "before": false,
       "after": true
     }],
-    "space-in-parens": [2, "never"],
-    "space-after-keywords": 2,
-    "space-before-blocks": 2,
+    "space-in-parens": [1, "never"],
+    "space-after-keywords": 1,
+    "space-before-blocks": 1,
     "space-before-function-paren": [
-      2,
+      1,
       "never"
     ],
-    "space-infix-ops": 2,
-    "space-return-throw-case": 2,
-    "spaced-comment": 2,
+    "space-infix-ops": 1,
+    "space-return-throw-case": 1,
+    "spaced-comment": 1,
   }
 }

--- a/javascript/linters/.eslintrc
+++ b/javascript/linters/.eslintrc
@@ -104,7 +104,7 @@
      */
     "block-scoped-var": 2,
     "consistent-return": 2,
-    "curly": [2, "multi"],
+    "curly": 1,
     "default-case": 1,
     "dot-notation": [2, {
       "allowKeywords": true


### PR DESCRIPTION
Most of the changes are switching from 2 (error) to 1 (warning) for purely style rules.

Ran eslint in app/scripts, before:
14871 problems (13584 errors, 1287 warnings)
after:
14869 problems (733 errors, 14136 warnings)

733 errors already seems like a doable thing to fix if we want to.
