### PR TITLE
RTFM fix for components methods order

### DIFF
--- a/javascript/linters/.eslintrc_react
+++ b/javascript/linters/.eslintrc_react
@@ -28,21 +28,9 @@
     "react/wrap-multilines": 0,
     "react/sort-comp": [2, {
       "order": [
-        "displayName",
-        "mixins",
-        "statics",
-        "propTypes",
-        "getDefaultProps",
-        "getInitialState",
-        "componentWillMount",
-        "componentDidMount",
-        "componentWillReceiveProps",
-        "shouldComponentUpdate",
-        "componentWillUpdate",
-        "componentWillUnmount",
+        "lifecycle",
         "/^on.+$/",
-        "/^get.+$/",
-        "/^((?!(render)).)+$/",
+        "everything-else",
         "/^render.+$/",
         "render"
       ]


### PR DESCRIPTION
ref https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
