### PR TITLE
Update to ESLint 3 and ESLint React 6

### DIFF
--- a/javascript/linters/.eslintrc
+++ b/javascript/linters/.eslintrc
@@ -1,25 +1,16 @@
 {
-  "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "jsx": true,
+      "experimentalObjectRestSpread": true
+    }
+  },
   "env": {
     "browser": true,
     "node": true
-  },
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "forOf": true,
-    "generators": false,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralDuplicateProperties": false,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true
   },
   "rules": {
     /**
@@ -120,7 +111,7 @@
     "no-caller": 2,
     "no-div-regex": 2,
     "no-else-return": 2,
-    "no-empty-label": 2,
+    "no-labels": 2,
     "no-eq-null": 2,
     "no-eval": 2,
     "no-extend-native": 2,
@@ -207,14 +198,13 @@
       "after": true
     }],
     "space-in-parens": [1, "never"],
-    "space-after-keywords": 1,
+    "keyword-spacing": [1, {"after": true}],
     "space-before-blocks": 1,
     "space-before-function-paren": [
       1,
       "never"
     ],
     "space-infix-ops": 1,
-    "space-return-throw-case": 1,
     "spaced-comment": 1,
   }
 }

--- a/javascript/linters/.eslintrc_react
+++ b/javascript/linters/.eslintrc_react
@@ -3,15 +3,10 @@
   "plugins": [
     "react"
   ],
-  {
-    "settings": {
-      "react": {
-        "version": "0.14"
-      }
+  "settings": {
+    "react": {
+      "version": "15.0"
     }
-  },
-  "ecmaFeatures": {
-    "jsx": true
   },
   "rules": {
     /**
@@ -30,7 +25,7 @@
     "react/jsx-sort-prop-types": 0,
     "react/jsx-uses-react": 2,
     "react/jsx-uses-vars": 2,
-    "react/no-did-mount-set-state": [2, "allow-in-func"],
+    "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-direct-mutation-state": 2,
     "react/no-multi-comp": 2,


### PR DESCRIPTION
- ESLint parser now supports ES6 so no need for eslint-babel
- Settings for ESLint React should be one level up
- A few rules have changed, see [the migration guide](http://eslint.org/docs/user-guide/migrating-to-2.0.0#removed-rules)
- react/no-did-mount-set-state defaults to allowing set-state in functions now

Ref https://github.com/lrqdo/front-web/issues/4011
