### PR TITLE
Add es6 to environment list

### DIFF
--- a/javascript/linters/.eslintrc
+++ b/javascript/linters/.eslintrc
@@ -10,7 +10,8 @@
   },
   "env": {
     "browser": true,
-    "node": true
+    "node": true,
+    "es6": true
   },
   "rules": {
     /**


### PR DESCRIPTION
This will fix all the `Promise is not defined` linting errors in our code.

ref: https://github.com/eslint/eslint/blob/4c5e9112a1e63c018666d0992f7fce7b71c21a76/conf/environments.js#L11
ref2: https://github.com/sindresorhus/globals/blob/d254dcaff737bd4873cf36ba9ce25a1eb0c4b372/globals.json#L136
