### PR TITLE
new scss rules

### DIFF
--- a/scss/linters/.scss-lint.yml
+++ b/scss/linters/.scss-lint.yml
@@ -71,7 +71,7 @@ linters:
     convention: ^[a-zA-Z0-9]+(?:-{1,2}[a-zA-Z0-9]+)?$ # or 'BEM', or a regex pattern
 
   NestingDepth:
-    max_depth: 5
+    max_depth: 4
 
   PlaceholderInExtend:
     enabled: true

--- a/scss/linters/.scss-lint.yml
+++ b/scss/linters/.scss-lint.yml
@@ -45,7 +45,7 @@ linters:
 
   HexNotation:
     enabled: true
-    style: uppercase # or 'lowercase'
+    style: lowercase # or 'uppercase'
 
   HexValidation:
     enabled: true
@@ -70,12 +70,14 @@ linters:
     enabled: false
     convention: ^[a-zA-Z0-9]+(?:-{1,2}[a-zA-Z0-9]+)?$ # or 'BEM', or a regex pattern
 
+  NestingDepth:
+    max_depth: 5
+
   PlaceholderInExtend:
     enabled: true
 
   PropertySortOrder:
-    enabled: true
-    ignore_unspecified: false
+    enabled: false
 
   PropertySpelling:
     enabled: true


### PR DESCRIPTION
Changement de quelques règles prédéfinies pour scss-lint :
 - le code hexadécimal doit être en lowercase puisque prettier le formatte comme ça (perso j'ai aucune préférence). Parce que je pense activer prettier pour le scss après
- Le nombre de "noeuds" en sass est désormais à 5 au lieu de 3 (la règle de 3 étant souvent pas respecté)
- on est plus obligé de mettre les propriétés par ordre alphabétique. Après pour mieux s'y retrouver dans le css, on peut imaginer une règle personalisée un peu plus logique qui obligerait à mettre d'abord la position, puis la taille, puis la typo... mais ça va faire des warnings partout dans les fichiers existants donc je pense que c'est pas le peine