### PR TITLE
add rule to include zero

### DIFF
--- a/scss/linters/.scss-lint.yml
+++ b/scss/linters/.scss-lint.yml
@@ -60,7 +60,7 @@ linters:
 
   LeadingZero:
     enabled: true
-    style: exclude_zero # or 'include_zero'
+    style: include_zero # or 'exclude_zero'
 
   MergeableSelector:
     enabled: true


### PR DESCRIPTION
Accorder ce que fait scsslint avec Prettier pour éviter ce warning :

![image](https://user-images.githubusercontent.com/20978445/62369727-d6e68500-b530-11e9-9729-500802377298.png)
