### PR TITLE
introduce React Hooks ESLint plugin

### DIFF
--- a/javascript/linters/.eslintrc_react_hooks
+++ b/javascript/linters/.eslintrc_react_hooks
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "react-hooks"
+  ],
+  "rules": {
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "styleguide",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Style reference",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ajout du plugin ESLint pour les hooks 👍  https://www.npmjs.com/package/eslint-plugin-react-hooks , tel que pointé par la doc de React Hooks : https://fr.reactjs.org/docs/hooks-overview.html

Configuré comme dans l'exemple premier lien.