### PR TITLE
[ESLint] Allow console calls in test files

### DIFF
--- a/javascript/linters/.eslintrc
+++ b/javascript/linters/.eslintrc
@@ -209,5 +209,13 @@
     ],
     "space-infix-ops": 1,
     "spaced-comment": 1,
-  }
+  },
+  "overrides": [
+    {
+      "files": ["test/functional/**/*.js", "test/unit/throwOnWarning.js"],
+      "rules": {
+        "no-console": 0
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Autorise les appels de type `console.log` dans les tests fonctionnels et unitaires, car c'est bien utile parfois et ça ne part pas en prod.